### PR TITLE
Build a release with GitHub Actions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,7 +24,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1
       
       - name: Setup NuGet
-        uses: NuGet/setup-nuget@v1.0.5
+        uses: NuGet/setup-nuget@v0.1.5
         
       - name: setup-msbuild
         uses: microsoft/setup-msbuild@v1.1
@@ -34,3 +34,64 @@ jobs:
       
       - name: Build solution
         run: msbuild SoleilEdit.sln -t:rebuild -property:Configuration=Release
+
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: drop
+          path: |
+            **/*.exe
+            **/*.dll
+            SoleilEdit/Docs/*
+            SoleilEdit/app.config
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: drop
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: 0.1.0
+          release_name: Release 0.1.0
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./drop/SoleilEdit.exe
+          asset_name: SoleilEdit.exe
+          asset_content_type: application/octet-stream
+
+      - name: Upload Additional Assets
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./drop/SoleilEdit/Docs
+          asset_name: Docs
+          asset_content_type: application/zip
+
+      - name: Upload Additional Assets
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./drop/SoleilEdit/app.config
+          asset_name: app.config
+          asset_content_type: text/xml

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '4.0.x'
 
       - name: Build and test
         run: |

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Package Release
         run: |
-          Compress-Archive -Path ./bin/Release/*, ./Docs/*, ./app.config, ./LICENSE, ./README.md -DestinationPath ./SoleilEdit.zip
+          Compress-Archive -Path ./SoleilEdit/bin/Release/*, ./SoleilEdit/Docs/*, ./SoleilEdit/app.config, ./SoleilEdit/LICENSE, ./SoleilEdit/README.md -DestinationPath ./SoleilEdit.zip
 
       - name: foo failure
         run: |

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -54,6 +54,11 @@ jobs:
         with:
           name: drop
 
+      - name: List files
+        run: |
+          echo "List files in drop directory:"
+          ls -R ./drop
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,32 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: Build and Test .NET Project
+
+on:
+  push:
+    branches:
+      - master
+      - build
+  pull_request:
+    branches:
+      - master
+      - build
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '6.0.x'
+
+      - name: Build and test
+        run: |
+          dotnet restore
+          dotnet build
+          dotnet test

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,18 +15,22 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-2019
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: '4.0.x'
-
-      - name: Build and test
-        run: |
-          dotnet restore
-          dotnet build
-          dotnet test
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1
+      
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1.0.5
+        
+      - name: setup-msbuild
+        uses: microsoft/setup-msbuild@v1.1
+      
+      - name: Restore Packages
+        run: nuget restore SoleilEdit.sln
+      
+      - name: Build solution
+        run: msbuild SoleilEdit.sln -t:rebuild -property:Configuration=Release

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,16 +5,11 @@ name: Build, Test and Package .NET Project release
 
 on:
   push:
-    branches:
-      - master
-      - build
-  pull_request:
-    branches:
-      - master
-      - build
+    tags:
+      - '*'
 
 jobs:
-  build_and_release:
+  build:
     runs-on: windows-2019
     steps:
       - name: Checkout code
@@ -37,8 +32,7 @@ jobs:
 
       - name: Package Release
         run: |
-          dir
-          Compress-Archive -Path ./SoleilEdit/bin/Release/*, ./SoleilEdit/Docs/*, ./SoleilEdit/app.config -DestinationPath ./SoleilEdit.zip
+          Compress-Archive -Path ./SoleilEdit/bin/Release/*, ./SoleilEdit/Docs/*, ./SoleilEdit/app.config, ./SoleilEdit/LICENSE, ./SoleilEdit/README.md -DestinationPath ./SoleilEdit.zip
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,6 +5,8 @@ name: Build, Test and Package .NET Project release
 
 on:
   push:
+    branches:
+      - fix-release
     tags:
       - '*'
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Package Release
         run: |
-          Compress-Archive -Path ./SoleilEdit/bin/Release/*, ./SoleilEdit/Docs/*, ./SoleilEdit/app.config, ./SoleilEdit/LICENSE, ./SoleilEdit/README.md -DestinationPath ./SoleilEdit.zip
+          Compress-Archive -Path ./SoleilEdit/bin/Release/*, ./SoleilEdit/Docs/*, ./SoleilEdit/app.config, ./LICENSE, ./README.md -DestinationPath ./SoleilEdit.zip
 
       - name: foo failure
         run: |

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,8 +5,6 @@ name: Build, Test and Package .NET Project release
 
 on:
   push:
-    branches:
-      - fix-release
     tags:
       - '*'
 
@@ -32,19 +30,9 @@ jobs:
       - name: Build solution
         run: msbuild SoleilEdit.sln -t:rebuild -property:Configuration=Release
 
-      - name: List files
-        run: |
-          echo "List files in current directory:"
-          dir
-
       - name: Package Release
         run: |
           Compress-Archive -Path ./SoleilEdit/bin/Release/*, ./SoleilEdit/Docs/*, ./SoleilEdit/app.config, ./LICENSE, ./README.md -DestinationPath ./SoleilEdit.zip
-
-      - name: foo failure
-        run: |
-          dir
-          dir foo
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -57,7 +57,7 @@ jobs:
       - name: List files
         run: |
           echo "List files in current directory:"
-          ls -l
+          ls -l SoleilEdit/
 
       - name: List dir files
         run: |

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,7 +1,7 @@
 # This workflow will build a .NET project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
-name: Build and Test .NET Project
+name: Build, Test and Package .NET Project release
 
 on:
   push:
@@ -14,7 +14,7 @@ on:
       - build
 
 jobs:
-  build:
+  build_and_release:
     runs-on: windows-2019
     steps:
       - name: Checkout code
@@ -35,34 +35,9 @@ jobs:
       - name: Build solution
         run: msbuild SoleilEdit.sln -t:rebuild -property:Configuration=Release
 
-      - name: Archive production artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: drop
-          path: |
-            **/*.exe
-            **/*.dll
-            SoleilEdit/Docs/*
-            SoleilEdit/app.config
-
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: drop
-
-      - name: List files
+      - name: Package Release
         run: |
-          echo "List files in current directory:"
-          ls -l SoleilEdit/
-
-      - name: List dir files
-        run: |
-          echo "List files in drop directory:"
-          ls -R ./drop
+          Compress-Archive -Path ./bin/Release/*, ./Docs/*, ./app.config -DestinationPath ./SoleilEdit.zip
 
       - name: Create Release
         id: create_release
@@ -70,8 +45,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: 0.1.0
-          release_name: Release 0.1.0
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
 
@@ -82,26 +57,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./drop/SoleilEdit.exe
-          asset_name: SoleilEdit.exe
-          asset_content_type: application/octet-stream
-
-      - name: Upload Additional Assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./drop/SoleilEdit/Docs
-          asset_name: Docs
+          asset_path: ./SoleilEdit.zip
+          asset_name: SoleilEdit.zip
           asset_content_type: application/zip
-
-      - name: Upload Additional Assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./drop/SoleilEdit/app.config
-          asset_name: app.config
-          asset_content_type: text/xml

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,7 +24,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1
       
       - name: Setup NuGet
-        uses: NuGet/setup-nuget@v0.1.5
+        uses: NuGet/setup-nuget@v1.0.5
         
       - name: setup-msbuild
         uses: microsoft/setup-msbuild@v1.1

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,9 +30,19 @@ jobs:
       - name: Build solution
         run: msbuild SoleilEdit.sln -t:rebuild -property:Configuration=Release
 
+      - name: List files
+        run: |
+          echo "List files in current directory:"
+          dir
+
       - name: Package Release
         run: |
-          Compress-Archive -Path ./SoleilEdit/bin/Release/*, ./SoleilEdit/Docs/*, ./SoleilEdit/app.config, ./SoleilEdit/LICENSE, ./SoleilEdit/README.md -DestinationPath ./SoleilEdit.zip
+          Compress-Archive -Path ./bin/Release/*, ./Docs/*, ./app.config, ./LICENSE, ./README.md -DestinationPath ./SoleilEdit.zip
+
+      - name: foo failure
+        run: |
+          dir
+          dir foo
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -56,6 +56,11 @@ jobs:
 
       - name: List files
         run: |
+          echo "List files in current directory:"
+          ls -l
+
+      - name: List dir files
+        run: |
           echo "List files in drop directory:"
           ls -R ./drop
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,7 +37,8 @@ jobs:
 
       - name: Package Release
         run: |
-          Compress-Archive -Path ./bin/Release/*, ./Docs/*, ./app.config -DestinationPath ./SoleilEdit.zip
+          dir
+          Compress-Archive -Path ./SoleilEdit/bin/Release/*, ./SoleilEdit/Docs/*, ./SoleilEdit/app.config -DestinationPath ./SoleilEdit.zip
 
       - name: Create Release
         id: create_release


### PR DESCRIPTION
It was my POC to learn capabilities of GitHub Actions to build a project working on obsolete .NET version, without Visual Studio installed locally.
By merging this PR it allows you to create a tag and this would trigger building release automatically, followed by packing ZIP.
Like as shown here:
![image](https://github.com/ShendoXT/soleiledit/assets/298544/9da5e7c4-d282-4d96-be75-24f91c344bdc)
